### PR TITLE
Implement a queue for the light actions

### DIFF
--- a/src/Devices/Device.cpp
+++ b/src/Devices/Device.cpp
@@ -90,17 +90,21 @@ namespace lightfx {
         }
 
         LFXE_API bool Device::Reset() {
-            if (this->lightActionUpdateThreadRunning) {
+            bool running = this->lightActionUpdateThreadRunning;
+
+            if (running) {
                 this->StopUpdateCurrentColorWorker();
-                this->ActiveLightAction = LightAction(this->GetNumberOfLights());
-                this->QueuedLightAction = {};
-                this->LightActionQueue = {};
-                this->StartUpdateCurrentColorWorker();
-            } else {
-                this->ActiveLightAction = LightAction(this->GetNumberOfLights());
-                this->QueuedLightAction = {};
-                this->LightActionQueue = {};
             }
+
+            this->ActiveLightAction = LightAction(this->GetNumberOfLights());
+            this->QueuedLightAction = {};
+            this->LightActionQueue = {};
+            this->LightActionQueueFlush = false;
+            
+            if (running) {
+                this->StartUpdateCurrentColorWorker();
+            }
+
             return true;
         }
 

--- a/src/Devices/Device.h
+++ b/src/Devices/Device.h
@@ -3,7 +3,9 @@
 // Standard includes
 #include <string>
 #include <mutex>
+#include <condition_variable>
 #include <thread>
+#include <queue>
 
 // Project includes
 #include "../Managers/DeviceManager.h"
@@ -59,11 +61,10 @@ namespace lightfx {
             virtual bool Update();
             virtual bool Reset();
 
-            LightAction GetCurrentLightAction();
+            LightAction GetActiveLightAction();
             LightAction GetQueuedLightAction();
+            LightAction GetLastLightAction();
             void QueueLightAction(const LightAction& lightAction);
-            
-            virtual bool PushColorToDevice() = 0;
 
             virtual const std::wstring GetDeviceName() = 0;
             virtual const DeviceType GetDeviceType() = 0;
@@ -75,13 +76,15 @@ namespace lightfx {
         protected:
             void SetNumberOfLights(const size_t numberOfLights);
 
-            LightAction CurrentLightAction = {};
+            LightAction ActiveLightAction = {};
             LightAction QueuedLightAction;
+            std::queue<LightAction> LightActionQueue;
+            std::mutex LightActionQueueMutex;
 
-            virtual void UpdateCurrentColorLoop();
-            virtual bool UpdateCurrentColor();
-            virtual void StartUpdateCurrentColor();
-            virtual void StopUpdateCurrentColor();
+            void StartUpdateCurrentColorWorker();
+            void StopUpdateCurrentColorWorker();
+            void UpdateCurrentColorWorkerThread();
+            virtual bool PushColorToDevice() = 0;
 
         private:
             bool isEnabled = false;
@@ -91,7 +94,8 @@ namespace lightfx {
 
             std::thread lightActionUpdateThread;
             bool lightActionUpdateThreadRunning = false;
-            std::mutex lightActionUpdateThreadRunningMutex;
+            std::mutex lightActionUpdateThreadMutex;
+            std::condition_variable lightActionUpdateThreadConditionVariable;
 
         };
 

--- a/src/Devices/Device.h
+++ b/src/Devices/Device.h
@@ -58,7 +58,7 @@ namespace lightfx {
 
             virtual bool Initialize();
             virtual bool Release();
-            virtual bool Update();
+            virtual bool Update(bool flushQueue = true);
             virtual bool Reset();
 
             LightAction GetActiveLightAction();
@@ -80,6 +80,7 @@ namespace lightfx {
             LightAction QueuedLightAction;
             std::queue<LightAction> LightActionQueue;
             std::mutex LightActionQueueMutex;
+            bool LightActionQueueFlush = false;
 
             void StartUpdateCurrentColorWorker();
             void StopUpdateCurrentColorWorker();

--- a/src/Devices/DeviceLightpack.cpp
+++ b/src/Devices/DeviceLightpack.cpp
@@ -83,7 +83,7 @@ namespace lightfx {
         bool DeviceLightpack::PushColorToDevice() {
             vector<LightpackColor> newLights = {};
             for (size_t i = 0; i < this->GetNumberOfLights(); ++i) {
-                LightColor color = this->CurrentLightAction.GetCurrentColor(i);
+                LightColor color = this->GetActiveLightAction().GetCurrentColor(i);
                 double brightness = color.brightness / 255.0;
                 int red = int(color.red * brightness);
                 int green = int(color.green * brightness);

--- a/src/Devices/DeviceLogitech.cpp
+++ b/src/Devices/DeviceLogitech.cpp
@@ -62,7 +62,7 @@ namespace lightfx {
         }
 
         LFXE_API bool DeviceLogitech::PushColorToDevice() {
-            LightColor color = this->CurrentLightAction.GetCurrentColor(0);
+            LightColor color = this->GetActiveLightAction().GetCurrentColor(0);
             double divider = (this->rangeOutMax - this->rangeOutMin) / ((this->rangeInMax - this->rangeInMin) / 100.0) / 100.0;
             double brightness = color.brightness / 255.0;
             double red = (color.red - this->rangeOutMin) / divider * brightness + this->rangeInMin;

--- a/src/Games/GameGw2.cpp
+++ b/src/Games/GameGw2.cpp
@@ -102,7 +102,7 @@ namespace lightfx {
                 for (size_t i = 0; i < deviceManager->GetChildrenCount(); ++i) {
                     auto device = deviceManager->GetChildByIndex(i);
                     LightAction lightAction = LightAction::NewPulse(device->GetNumberOfLights(), startColor, endColor, 200, 100, 400, 5);
-                    lightAction.SetResetColor(device->GetCurrentLightAction().GetResetColor());
+                    lightAction.SetResetColor(device->GetLastLightAction().GetResetColor());
                     device->QueueLightAction(lightAction);
                     device->Update();
                 }

--- a/src/LightFXExports.cpp
+++ b/src/LightFXExports.cpp
@@ -260,7 +260,7 @@ extern "C" {
         }
 
         try {
-            *lightCol = LightColorToLfxColor(device->GetCurrentLightAction().GetCurrentColor(lightIndex));
+            *lightCol = LightColorToLfxColor(device->GetActiveLightAction().GetCurrentColor(lightIndex));
         } catch (...) {
             return LFX_FAILURE;
         }
@@ -353,7 +353,7 @@ extern "C" {
                 lightAction = LightAction::NewInstant(device->GetNumberOfLights(), LfxColorToLightColor(*primaryCol));
                 break;
             }
-            lightAction.SetStartColor(device->GetCurrentLightAction().GetCurrentColor());
+            lightAction.SetStartColor(device->GetActiveLightAction().GetCurrentColor());
             deviceManager->GetChildByIndex(devIndex)->QueueLightAction(lightAction);
         } catch (...) {
             return LFX_FAILURE;

--- a/tests/Devices/DeviceMock.h
+++ b/tests/Devices/DeviceMock.h
@@ -24,8 +24,9 @@ namespace lightfx_tests {
             using Device::Update;
             using Device::Reset;
 
-            using Device::GetCurrentLightAction;
+            using Device::GetActiveLightAction;
             using Device::GetQueuedLightAction;
+            using Device::GetLastLightAction;
             using Device::QueueLightAction;
 
             virtual bool PushColorToDevice() override { return false; }
@@ -36,12 +37,6 @@ namespace lightfx_tests {
             using Device::GetNumberOfLights;
             using Device::GetLightData;
             using Device::SetLightData;
-
-        protected:
-            using Device::SetNumberOfLights;
-
-            using Device::CurrentLightAction;
-            using Device::QueuedLightAction;
 
         };
 

--- a/tests/Devices/DeviceTest.cpp
+++ b/tests/Devices/DeviceTest.cpp
@@ -20,6 +20,7 @@ public:
         Assert::IsFalse(device->IsEnabled());
         device->Enable();
         Assert::IsTrue(device->IsEnabled());
+        device->Disable();
     }
 
     TEST_METHOD(Disable) {
@@ -60,7 +61,19 @@ public:
         LightAction lightAction = LightAction::NewInstant(1, LightColor(1, 2, 3, 4));
         device->QueueLightAction(lightAction);
         device->Update();
-        Assert::IsTrue(lightAction.GetStartColor(0) == device->GetCurrentLightAction().GetStartColor(0));
+
+        bool success = false;
+        for (int i = 0; i < 500; ++i) {
+            if (lightAction.GetStartColor(0) == device->GetActiveLightAction().GetStartColor(0)) {
+                success = true;
+                break;
+            }
+            this_thread::sleep_for(chrono::milliseconds(1));
+        }
+        if (!success) {
+            Assert::Fail(L"Active light actions do not match after an extended period of time");
+        }
+        device->Disable();
     }
 
         };


### PR DESCRIPTION
Instead of starting a new thread every time a light action gets pushed, there's now a dedicated thread for every enabled device that manages a queue with light actions.
