### PR TITLE
Workaround for Logitech G110 bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,12 @@ open `settings.json` within the configuration folder (see
 ## Support
 ### Hardware
 - Logitech keyboards and mice with LEDs through Logitech Gaming Software
-8.58.177 or higher (8.57.145 is supported as well, but requires
-[additional configuration](https://github.com/Archomeda/lightfx-extender/wiki/Logitech-Color-Range))
+8.58.177 or higher
+  - Version 8.57.145 is supported as well, but requires
+[additional configuration](https://github.com/Archomeda/lightfx-extender/wiki/Logitech-Color-Range)
+  - For version 8.58.177 and lower, G110 users have to enable
+[a workaround](https://github.com/Archomeda/lightfx-extender/wiki/Logitech-G110-Workaround)
+for a bug that will be fixed in an upcoming version
 - Lightpack devices through a recent version of Prismatik (or similar hardware
 and software that support the same API, tested on version 5.11.1 only)
 

--- a/src/Config/MainConfigFile.cpp
+++ b/src/Config/MainConfigFile.cpp
@@ -30,6 +30,7 @@
 #define CONF_DEVICES_LOGITECH_COLORRANGE_OUTMAX L"LightFXMax"
 #define CONF_DEVICES_LOGITECH_COLORRANGE_INMIN L"LogitechMin"
 #define CONF_DEVICES_LOGITECH_COLORRANGE_INMAX L"LogitechMax"
+#define CONF_DEVICES_LOGITECH_G110WORKAROUND L"G110WorkaroundEnabled"
 
 #define CONF_DEVICES_LIGHTPACK L"Lightpack"
 #define CONF_DEVICES_LIGHTPACK_API L"SocketApi"
@@ -72,6 +73,7 @@ namespace lightfx {
             this->LogitechColorRangeOutMax = 255;
             this->LogitechColorRangeInMin = 0;
             this->LogitechColorRangeInMax = 100;
+            this->LogitechG110WorkaroundEnabled = false;
 
             this->GuildWars2TeamColorEnabled = true;
             this->GuildWars2TeamColorAnimation = L"Pulse";
@@ -166,6 +168,7 @@ namespace lightfx {
             objLogitechColorRange.AddMember(CONF_DEVICES_LOGITECH_COLORRANGE_INMIN, this->LogitechColorRangeInMin, allocator);
             objLogitechColorRange.AddMember(CONF_DEVICES_LOGITECH_COLORRANGE_INMAX, this->LogitechColorRangeInMax, allocator);
             objLogitech.AddMember(CONF_DEVICES_LOGITECH_COLORRANGE, objLogitechColorRange, allocator);
+            objLogitech.AddMember(CONF_DEVICES_LOGITECH_G110WORKAROUND, this->LogitechG110WorkaroundEnabled, allocator);
 
             obj.AddMember(CONF_DEVICES_LOGITECH, objLogitech, allocator);
 
@@ -291,6 +294,9 @@ namespace lightfx {
                         if (colorRange.HasMember(CONF_DEVICES_LOGITECH_COLORRANGE_INMAX) && colorRange[CONF_DEVICES_LOGITECH_COLORRANGE_INMAX].IsInt()) {
                             this->LogitechColorRangeInMax = colorRange[CONF_DEVICES_LOGITECH_COLORRANGE_INMAX].GetInt();
                         }
+                    }
+                    if (objLogitech.HasMember(CONF_DEVICES_LOGITECH_G110WORKAROUND) && objLogitech[CONF_DEVICES_LOGITECH_G110WORKAROUND].IsBool()) {
+                        this->LogitechG110WorkaroundEnabled = objLogitech[CONF_DEVICES_LOGITECH_G110WORKAROUND].GetBool();
                     }
                 }
             }

--- a/src/Config/MainConfigFile.h
+++ b/src/Config/MainConfigFile.h
@@ -43,6 +43,7 @@ namespace lightfx {
             int LogitechColorRangeOutMax = 255;
             int LogitechColorRangeInMin = 0;
             int LogitechColorRangeInMax = 100;
+            bool LogitechG110WorkaroundEnabled = false;
 
             bool GuildWars2TeamColorEnabled = true;
             std::wstring GuildWars2TeamColorAnimation = L"Pulse";

--- a/src/Devices/DeviceLogitech.cpp
+++ b/src/Devices/DeviceLogitech.cpp
@@ -32,6 +32,11 @@ namespace lightfx {
             this->rangeInMax = inMax;
         }
 
+        LFXE_API void DeviceLogitech::SetG110FixEnabled(const bool enabled) {
+            this->g110FixEnabled = enabled;
+        }
+
+
         LFXE_API bool DeviceLogitech::Initialize() {
             if (!this->IsInitialized()) {
                 if (Device::Initialize()) {
@@ -75,11 +80,23 @@ namespace lightfx {
         }
 
         LFXE_API bool DeviceLogitech::PushColorToDevice(const vector<LightColor>& colors) {
+            double red = colors[0].red;
+            double green = colors[0].green;
+            double blue = colors[0].blue;
+
+            if (this->g110FixEnabled) {
+                double total = red + blue;
+                if (total > 255) {
+                    red = red * 255 / total;
+                    blue = blue * 255 / total;
+                }
+            }
+
             double divider = (this->rangeOutMax - this->rangeOutMin) / ((this->rangeInMax - this->rangeInMin) / 100.0) / 100.0;
             double brightness = colors[0].brightness / 255.0;
-            double red = (colors[0].red - this->rangeOutMin) / divider * brightness + this->rangeInMin;
-            double green = (colors[0].green - this->rangeOutMin) / divider * brightness + this->rangeInMin;
-            double blue = (colors[0].blue - this->rangeOutMin) / divider * brightness + this->rangeInMin;
+            red = (red - this->rangeOutMin) / divider * brightness + this->rangeInMin;
+            green = (green - this->rangeOutMin) / divider * brightness + this->rangeInMin;
+            blue = (blue - this->rangeOutMin) / divider * brightness + this->rangeInMin;
 
             LOG(LogLevel::Debug, L"Update color to (" + to_wstring(red) + L"," + to_wstring(green) + L"," + to_wstring(blue) + L")");
 

--- a/src/Devices/DeviceLogitech.cpp
+++ b/src/Devices/DeviceLogitech.cpp
@@ -32,8 +32,8 @@ namespace lightfx {
             this->rangeInMax = inMax;
         }
 
-        LFXE_API void DeviceLogitech::SetG110FixEnabled(const bool enabled) {
-            this->g110FixEnabled = enabled;
+        LFXE_API void DeviceLogitech::SetG110WorkaroundEnabled(const bool enabled) {
+            this->g110WorkaroundEnabled = enabled;
         }
 
 
@@ -84,7 +84,7 @@ namespace lightfx {
             double green = colors[0].green;
             double blue = colors[0].blue;
 
-            if (this->g110FixEnabled) {
+            if (this->g110WorkaroundEnabled) {
                 double total = red + blue;
                 if (total > 255) {
                     red = red * 255 / total;

--- a/src/Devices/DeviceLogitech.h
+++ b/src/Devices/DeviceLogitech.h
@@ -14,7 +14,7 @@ namespace lightfx {
 
         public: 
             void SetRange(const int outMin, const int outMax, const int inMin, const int inMax);
-            void SetG110FixEnabled(const bool enabled);
+            void SetG110WorkaroundEnabled(const bool enabled);
 
             virtual bool Initialize() override;
             virtual bool Enable() override;
@@ -32,7 +32,7 @@ namespace lightfx {
             int rangeInMin = 0;
             int rangeInMax = 100;
 
-            bool g110FixEnabled = false;
+            bool g110WorkaroundEnabled = false;
 
         };
 

--- a/src/Devices/DeviceLogitech.h
+++ b/src/Devices/DeviceLogitech.h
@@ -14,6 +14,7 @@ namespace lightfx {
 
         public: 
             void SetRange(const int outMin, const int outMax, const int inMin, const int inMax);
+            void SetG110FixEnabled(const bool enabled);
 
             virtual bool Initialize() override;
             virtual bool Enable() override;
@@ -30,6 +31,8 @@ namespace lightfx {
             int rangeOutMax = 255;
             int rangeInMin = 0;
             int rangeInMax = 100;
+
+            bool g110FixEnabled = false;
 
         };
 

--- a/src/Managers/DeviceManager.cpp
+++ b/src/Managers/DeviceManager.cpp
@@ -39,6 +39,7 @@ namespace lightfx {
 
             auto logitech = make_shared<DeviceLogitech>();
             this->AddChild(L"Logitech", logitech);
+            logitech->SetG110WorkaroundEnabled(config->LogitechG110WorkaroundEnabled);
             if (logitech->Initialize()) {
                 ++i;
             }


### PR DESCRIPTION
This is the workaround for #13. It assures that the combined value of red and blue never exceed 255. The values will get scaled if it does.

I decided to go with 255 instead of a more precise value as explained in the issue, since this value is the guaranteed limit of the overflow and it doesn't really matter anyway, because it seems that the G110 only has 16 possible intensity values. Within 255 and 271, there should be no visual change in intensity.

In order to use the workaround, an extra configuration has been provided, since I have no way of telling which version of LGS is running and which device is connected :cry:

Fixes #13.
