### PR TITLE
Use a separate thread for the tray icon

### DIFF
--- a/src/Managers/TrayManager.h
+++ b/src/Managers/TrayManager.h
@@ -2,6 +2,7 @@
 
 // Standard includes
 #include <string>
+#include <thread>
 #include <vector>
 
 // Windows includes
@@ -47,6 +48,10 @@ namespace lightfx {
             NOTIFYICONDATAW trayIconData = {};
 
             bool isTrayIconAdded = false;
+            bool isTrayIconRemoving = false;
+            std::thread trayIconThread;
+
+            void AddTrayIconThreaded();
 
             static LRESULT CALLBACK WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
             void TrayIconCallback(WPARAM wParam, LPARAM lParam);


### PR DESCRIPTION
Using a separate thread for the tray icon won't freeze the game's main thread anymore when right clicked and might solve other issues regarding the icon as well.
