### PR TITLE
Add Clevo devices support to LightFX-Extender

### DIFF
--- a/LightFXExtender.sln
+++ b/LightFXExtender.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.30723.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.24720.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "LightFXExtender", "src\LightFXExtender.vcxproj", "{A8CB3988-1ADA-4631-A7D3-11D7F68776A3}"
 EndProject

--- a/src/Devices/DeviceClevo.cpp
+++ b/src/Devices/DeviceClevo.cpp
@@ -54,23 +54,23 @@ namespace lightfx {
 				// Set Light Data
 				LightData lightDataKBLeft;
 				lightDataKBLeft.Name = L"KBLeft";
-				lightDataKBLeft.Position = { 1, 1, 2 };
+				lightDataKBLeft.Position = { 13, 2, 10 };
 				this->SetLightData(0, lightDataKBLeft); // Keyboard Left
 
 				LightData lightDataKBCenter;
 				lightDataKBCenter.Name = L"KBCenter";
-				lightDataKBCenter.Position = { 2, 1, 2 };
+				lightDataKBCenter.Position = { 26, 2, 10 };
 				this->SetLightData(1, lightDataKBCenter); // Keyboard Center
 
 				LightData lightDataKBRight;
 				lightDataKBRight.Name = L"KBRight";
-				lightDataKBRight.Position = { 3, 1, 2 };
+				lightDataKBRight.Position = { 40, 2, 10 };
 				this->SetLightData(2, lightDataKBRight); // Keyboard Right
 
 				if (this->useTouchpad) {
 					LightData lightDataTouchpad;
 					lightDataTouchpad.Name = L"TouchPad";
-					lightDataTouchpad.Position = { 2, 1, 4 };
+					lightDataTouchpad.Position = { 20, 2, 20 };
 					this->SetLightData(3, lightDataTouchpad); // Touchpad
 				}
 
@@ -124,6 +124,27 @@ namespace lightfx {
 				blocking_color.setInitialized(true);
 			}
 
+			// Optimization Variables
+			int kbleft_r =		-1;
+			int kbleft_g =		-1;
+			int kbleft_b =		-1;
+			int kbleft_a =		-1;
+			int kbcenter_r =	-1;
+			int kbcenter_g =	-1;
+			int kbcenter_b =	-1;
+			int kbcenter_a =	-1;
+			int kbright_r =		-1;
+			int kbright_g =		-1;
+			int kbright_b =		-1;
+			int kbright_a =		-1;
+			//if (useTouchpad) {
+				int tp_r =		-1;
+				int tp_g =		-1;
+				int tp_b =		-1;
+				int tp_a =		-1;
+			//}
+
+			// Main Loop
 			while (true) {
 
 				const vector<LightColor> colors = blocking_color.getLightColor(); // Blocking structure blocks the thread execution till it receives a new color
@@ -133,19 +154,44 @@ namespace lightfx {
 					clevo.Release(); // Release
 					return; // Close Thread
 				}
-				
-				// Left KB Colors
-				clevo.SetKBLED(ColorKBLeft, colors[0].red, colors[0].green, colors[0].blue, (colors[0].brightness / 255.0));
 
-				// Middle KB Colors
-				clevo.SetKBLED(ColorKBCenter, colors[1].red, colors[1].green, colors[1].blue, (colors[1].brightness / 255.0));
+				// Left KB Colors
+				if (kbleft_r != colors[0].red || kbleft_g != colors[0].green || kbleft_b != colors[0].blue || kbleft_a != colors[0].brightness) {
+					clevo.SetKBLED(ColorKBLeft, colors[0].red, colors[0].green, colors[0].blue, (colors[0].brightness / 255.0));
+					kbleft_r = colors[0].red;
+					kbleft_g = colors[0].green;
+					kbleft_b = colors[0].blue;
+					kbleft_a = colors[0].brightness;
+				}
+				
+
+				// Center KB Colors
+				if (kbcenter_r != colors[1].red || kbcenter_g != colors[1].green || kbcenter_b != colors[1].blue || kbcenter_a != colors[1].brightness) {
+					clevo.SetKBLED(ColorKBCenter, colors[1].red, colors[1].green, colors[1].blue, (colors[1].brightness / 255.0));
+					kbcenter_r = colors[1].red;
+					kbcenter_g = colors[1].green;
+					kbcenter_b = colors[1].blue;
+					kbcenter_a = colors[1].brightness;
+				}
 
 				// Right KB Colors
-				clevo.SetKBLED(ColorKBRight, colors[2].red, colors[2].green, colors[2].blue, (colors[2].brightness / 255.0));
+				if (kbright_r != colors[2].red || kbright_g != colors[2].green || kbright_b != colors[2].blue || kbright_a != colors[2].brightness) {
+					clevo.SetKBLED(ColorKBRight, colors[2].red, colors[2].green, colors[2].blue, (colors[2].brightness / 255.0));
+					kbright_r = colors[2].red;
+					kbright_g = colors[2].green;
+					kbright_b = colors[2].blue;
+					kbright_a = colors[2].brightness;
+				}
 
 				// Touchpad Colors
 				if (useTouchpad) {
-					clevo.SetKBLED(ColorTouchpad, colors[3].red, colors[3].green, colors[3].blue, (colors[3].brightness / 255.0));
+					if (tp_r != colors[3].red || tp_g != colors[3].green || tp_b != colors[3].blue || tp_a != colors[3].brightness) {
+						clevo.SetKBLED(ColorTouchpad, colors[3].red, colors[3].green, colors[3].blue, (colors[3].brightness / 255.0));
+						tp_r = colors[3].red;
+						tp_g = colors[3].green;
+						tp_b = colors[3].blue;
+						tp_a = colors[3].brightness;
+					}
 				}
 			}
 		}

--- a/src/Devices/DeviceClevo.cpp
+++ b/src/Devices/DeviceClevo.cpp
@@ -1,0 +1,143 @@
+#ifndef LFXE_EXPORTS
+#define LFXE_EXPORTS
+#endif
+
+#include "DeviceClevo.h"
+
+// Standard includes
+#include <tchar.h>
+#include <thread>
+
+// Project includes
+#include "../LightFXExtender.h"
+#include "../Utils/Log.h"
+#include "Libraries/ClevoKBLED.h"
+
+
+using namespace std;
+using namespace lightfx::devices::proxies;
+using namespace lightfx::managers;
+using namespace lightfx::timelines;
+using namespace lightfx::utils;
+
+namespace lightfx {
+	namespace devices {
+
+		void ClevoSetKBLEDThread(BlockingLightColor blocking_color, bool useTouchpad);
+
+		BlockingLightColor color = BlockingLightColor(); // TODO: Move to INITIALIZE function
+
+		LFXE_API bool DeviceClevo::Initialize() {
+			if (!this->IsInitialized()) {
+
+				// Start WMI Thread (Cannot be run on Main thread because of WMI CoInitializeEx issues on main thread)
+				thread clevo_wmi_thread(&ClevoSetKBLEDThread, color, this->useTouchpad);
+				clevo_wmi_thread.detach();
+
+				// Set up number of lights
+				unsigned int numLights = 3; // 3 = Only Keyboard - 4 = Keyboard + Touchpad
+
+				if (this->useTouchpad) {
+					numLights = 4;
+				}
+
+				this->SetNumberOfLights(numLights);
+				LOG_WARNING(to_wstring(numLights) + L" lights available");
+
+				// Set Light Data
+				LightData lightDataKBLeft;
+				lightDataKBLeft.Name = L"KBLeft";
+				lightDataKBLeft.Position = { 1, 1, 2 };
+				this->SetLightData(0, lightDataKBLeft); // Keyboard Left
+
+				LightData lightDataKBCenter;
+				lightDataKBCenter.Name = L"KBCenter";
+				lightDataKBCenter.Position = { 2, 1, 2 };
+				this->SetLightData(1, lightDataKBCenter); // Keyboard Center
+
+				LightData lightDataKBRight;
+				lightDataKBRight.Name = L"KBRight";
+				lightDataKBRight.Position = { 3, 1, 2 };
+				this->SetLightData(2, lightDataKBRight); // Keyboard Right
+
+				if (this->useTouchpad) {
+					LightData lightDataTouchpad;
+					lightDataTouchpad.Name = L"TouchPad";
+					lightDataTouchpad.Position = { 2, 1, 4 };
+					this->SetLightData(3, lightDataTouchpad); // Touchpad
+				}
+
+				// Mark as initialized
+				this->SetInitialized(true);
+				// this->Reset(); // TODO: Is this required or not? Unsure..
+
+			}
+			return true;
+		}
+
+		LFXE_API bool DeviceClevo::Release() {
+			if (this->IsInitialized()) {
+
+				color.releaseThread(); // Set Release State
+
+				this->SetInitialized(false);
+			}
+			return true;
+		}
+
+		LFXE_API bool DeviceClevo::Enable() {
+			if (!this->IsEnabled()) {
+				this->SetEnabled(TRUE);
+				// TODO: Enable Device? Not really required.
+			}
+			return true;
+		}
+
+		LFXE_API bool DeviceClevo::Disable() {
+			if (this->IsEnabled()) {
+				this->SetEnabled(FALSE);
+				// TODO: Disable Device? Turn all keys to black color could be an option. Not really required.
+			}
+			return true;
+		}
+
+		LFXE_API bool DeviceClevo::PushColorToDevice(const vector<LightColor>& colors) {
+			color.setLightColor(colors);
+			return TRUE;
+		}
+
+		// Separate Thread for WMI Interface
+		void ClevoSetKBLEDThread(BlockingLightColor blocking_color, bool useTouchpad) {
+
+			ClevoKBLED clevo = ClevoKBLED();
+
+			// Initialize COM
+			clevo.Initialize();
+
+			while (true) {
+
+				const vector<LightColor> colors = blocking_color.getLightColor(); // Blocking structure blocks the thread execution till it receives a new color
+
+				// Release Thread
+				if (blocking_color.getReleaseThreadState() == true) {
+					clevo.Release(); // Release
+					return; // Close Thread
+				}
+				
+				// Left KB Colors
+				clevo.SetKBLED(ColorKBLeft, colors[0].red, colors[0].green, colors[0].blue, (colors[0].brightness / 255.0));
+
+				// Middle KB Colors
+				clevo.SetKBLED(ColorKBCenter, colors[1].red, colors[1].green, colors[1].blue, (colors[1].brightness / 255.0));
+
+				// Right KB Colors
+				clevo.SetKBLED(ColorKBRight, colors[2].red, colors[2].green, colors[2].blue, (colors[2].brightness / 255.0));
+
+				// Touchpad Colors
+				if (useTouchpad) {
+					clevo.SetKBLED(ColorTouchpad, colors[3].red, colors[3].green, colors[3].blue, (colors[3].brightness / 255.0));
+				}
+			}
+		}
+	}
+}

--- a/src/Devices/DeviceClevo.cpp
+++ b/src/Devices/DeviceClevo.cpp
@@ -34,6 +34,13 @@ namespace lightfx {
 				thread clevo_wmi_thread(&ClevoSetKBLEDThread, color, this->useTouchpad);
 				clevo_wmi_thread.detach();
 
+				// Gather Initialized Status
+				if (color.getInitialized() == false) {
+					// Mark as uninitialized
+					this->SetInitialized(false);
+					return false;
+				}
+
 				// Set up number of lights
 				unsigned int numLights = 3; // 3 = Only Keyboard - 4 = Keyboard + Touchpad
 
@@ -69,7 +76,6 @@ namespace lightfx {
 
 				// Mark as initialized
 				this->SetInitialized(true);
-				// this->Reset(); // TODO: Is this required or not? Unsure..
 
 			}
 			return true;
@@ -112,7 +118,11 @@ namespace lightfx {
 			ClevoKBLED clevo = ClevoKBLED();
 
 			// Initialize COM
-			clevo.Initialize();
+			if (clevo.Initialize() != 0) {
+				blocking_color.setInitialized(false);
+			}else {
+				blocking_color.setInitialized(true);
+			}
 
 			while (true) {
 

--- a/src/Devices/DeviceClevo.h
+++ b/src/Devices/DeviceClevo.h
@@ -1,0 +1,41 @@
+#pragma once
+
+// Project includes
+#include "Device.h"
+#include "Libraries/ClevoKBLED.h"
+#include "../Utils/BlockingLightColor.h"
+
+// API exports
+#include "../Common/ApiExports.h"
+
+#pragma warning(push)
+#pragma warning(disable : 4251)
+
+using namespace lightfx::utils;
+
+namespace lightfx {
+	namespace devices {
+
+		class LFXE_API DeviceClevo : public Device {
+
+		public:
+			virtual bool Initialize() override;
+			virtual bool Release() override;
+
+			virtual bool Enable() override;
+			virtual bool Disable() override;
+
+			virtual const std::wstring GetDeviceName() override { return L"Clevo"; }
+			virtual const DeviceType GetDeviceType() override { return DeviceType::DeviceKeyboard; }
+
+		protected:
+			virtual bool PushColorToDevice(const std::vector<timelines::LightColor>& colors) override;
+
+		private:
+			bool useTouchpad = true;
+		};
+
+	}
+}
+
+#pragma warning(pop)

--- a/src/Devices/DeviceLightpack.cpp
+++ b/src/Devices/DeviceLightpack.cpp
@@ -47,8 +47,8 @@ namespace lightfx {
                         for (size_t i = 0; i < this->GetNumberOfLights(); ++i) {
                             LightData light;
                             light.Name = to_wstring(leds[i].index);
-                            int posX = int(((leds[i].x - screen.x) + (leds[i].width / 2)) / divider);
-                            int posY = int(((screen.height - leds[i].y - screen.y) + (leds[i].height / 2)) / divider);
+                            unsigned int posX = int(((leds[i].x - screen.x) + (leds[i].width / 2)) / divider);
+                            unsigned int posY = int(((screen.height - leds[i].y - screen.y) + (leds[i].height / 2)) / divider);
                             light.Position = { posX, posY, 0 };
                             LOG_DEBUG(L"Get LED " + to_wstring(i) + L" pos: (" + to_wstring(posX) + L"," + to_wstring(posY) + L")");
                             this->SetLightData(i, light);

--- a/src/Devices/Libraries/ClevoKBLED.cpp
+++ b/src/Devices/Libraries/ClevoKBLED.cpp
@@ -1,0 +1,220 @@
+
+#include <Windows.h>  
+#include <iostream>  
+#include <string> 
+#include <WbemCli.h>  
+#include <atlbase.h>
+#include <comutil.h>
+#include <comdef.h>
+#include <thread>
+
+#include "ClevoKBLED.h"
+
+#include "../../Timelines/LightColor.h"
+#include "../../Utils/Log.h"
+
+#pragma comment(lib, "wbemuuid.lib")  
+
+using std::cout;
+using std::cin;
+using std::endl;
+using std::hex;
+using std::vector;
+using std::string;
+
+using namespace lightfx::timelines;
+using namespace lightfx::utils;
+
+// Functions
+// Initialize connection to Clevo WMI Class
+HRESULT ClevoKBLED::Initialize(){
+
+	HRESULT hRes;
+
+	// Initialize COM. ------------------------------------------
+	if (FAILED(hRes = CoInitializeEx(NULL, COINIT_MULTITHREADED)))
+	{
+		LOG_WARNING(L"Unable to launch COM: 0x" + std::to_wstring(hRes));
+		cout << "Unable to launch COM: 0x" << hex << hRes << endl;
+		//return hRes;
+	}
+
+	// Set general COM security levels --------------------------
+	if ((FAILED(hRes = CoInitializeSecurity(NULL, -1, NULL, NULL, RPC_C_AUTHN_LEVEL_CONNECT, RPC_C_IMP_LEVEL_IMPERSONATE, NULL, EOAC_NONE, 0))))
+	{
+		LOG_WARNING(L"Unable to initialize security: 0x"+ std::to_wstring(hRes));
+		cout << "Unable to initialize security: 0x" << hex << hRes << endl;
+		//return hRes;
+	}
+
+	// Obtain the initial locator to WMI -------------------------
+	IWbemLocator* pLocator = NULL;
+	if (FAILED(hRes = CoCreateInstance(CLSID_WbemLocator, NULL, CLSCTX_ALL, IID_PPV_ARGS(&pLocator))))
+	{
+		LOG_WARNING(L"Unable to create a WbemLocator: 0x" + std::to_wstring(hRes));
+		cout << "Unable to create a WbemLocator: 0x" << hex << hRes << endl;
+		return hRes; // Program has failed. 
+	}
+
+	// Connect to WMI through the IWbemLocator::ConnectServer method
+	// IWbemServices* pService = NULL;
+	if (FAILED(hRes = pLocator->ConnectServer(_bstr_t(L"root\\WMI"), NULL, NULL, NULL, WBEM_FLAG_CONNECT_USE_MAX_WAIT, NULL, NULL, &pService)))
+	{
+		pLocator->Release();
+		LOG_WARNING(L"Unable to connect to \"root\\WMI\": 0x" + std::to_wstring(hRes));
+		cout << "Unable to connect to \"root\\WMI\": 0x" << hex << hRes << endl;
+		return hRes; // Program has failed. 
+	}
+
+
+	// Set security levels on the proxy ------------------------- 
+	if (FAILED(hRes = CoSetProxyBlanket(pService, RPC_C_AUTHN_WINNT, RPC_C_AUTHZ_NONE, NULL, RPC_C_AUTHN_LEVEL_CALL, RPC_C_IMP_LEVEL_IMPERSONATE, NULL, EOAC_NONE)))
+	{
+		LOG_WARNING(L"Could not set proxy blanket. Error code = 0x");
+		cout << "Could not set proxy blanket. Error code = 0x" << hex << hRes << endl;
+		pService->Release();
+		pLocator->Release();
+		CoUninitialize();
+		return hRes; // Program has failed. 
+	}
+
+	// Query the COM system. ------------------------------------
+	IEnumWbemClassObject* pEnumerator = NULL;
+	if (FAILED(hRes = pService->ExecQuery(_bstr_t(L"WQL"), _bstr_t(L"SELECT * FROM CLEVO_GET"), WBEM_FLAG_FORWARD_ONLY | WBEM_FLAG_RETURN_IMMEDIATELY, NULL, &pEnumerator)))
+	{
+		LOG_WARNING(L"Query for CLEVO_GET failed. Error code = 0x");
+		cout << "Query for CLEVO_GET failed. Error code = 0x" << hex << hRes << endl;
+		pService->Release();
+		pLocator->Release();
+		CoUninitialize();
+		return hRes; // Program has failed.
+	}
+
+	// Iterate trough the results. ------------------------------------
+	IWbemClassObject *pclsObj = NULL;
+	ULONG uReturn = 0;
+
+	while (pEnumerator)
+	{
+		hRes = pEnumerator->Next(WBEM_INFINITE, 1, &pclsObj, &uReturn);
+
+		if (0 == uReturn)
+		{
+			break;
+		}
+
+		// Get SetKBLED Parameters
+		IWbemClassObject *clevo = NULL;
+		IWbemClassObject *params = NULL;
+		// IWbemClassObject *paramsInst = NULL;
+
+		pService->GetObject(_bstr_t(L"CLEVO_GET"), 0, NULL, &clevo, NULL);
+
+		if (FAILED(hRes = clevo->GetMethod(_bstr_t(L"SetKBLED"), 0, &params, NULL))) {
+			LOG_WARNING(L"could not get method SetKBLED. Error code = 0x");
+			cout << "could not get method SetKBLED. Error code = 0x" << hex << hRes << endl;
+			return hRes; // Program has failed. 
+		}
+
+		if (FAILED(hRes = params->SpawnInstance(0, &paramsInst))) {
+			LOG_WARNING(L"could not spawn params instance. Error code = 0x" );
+			cout << "could not spawn params instance. Error code = 0x" << hex << hRes << endl;
+			return hRes; // Program has failed. 
+		}
+
+		// This Pointer
+		CIMTYPE type;
+		LONG flavor;
+		pclsObj->Get(L"__PATH", 0, &this_pointer, &type, &flavor);
+
+		// Cleanup
+		pclsObj->Release();
+		pEnumerator->Release();
+		pLocator->Release();
+
+		return 0;
+	}
+
+	return 1;
+}
+
+// Release Resources
+HRESULT ClevoKBLED::Release() {
+	// TODO: Restore keyboard lights from before
+
+	if (pService != NULL) {
+		pService->Release();
+	}
+
+	if (paramsInst != NULL) {
+		paramsInst->Release();
+	}
+
+	// TODO: Check if everything is being cleaned up
+	CoUninitialize();
+	return 0;
+}
+
+// Set KBLED: Pass RAW hex value
+HRESULT ClevoKBLED::SetKBLED(uint32_t hex_value) {
+
+	// LOG_WARNING(L"Updating KB Lights (CLEVO)");
+
+	HRESULT hRes;
+
+	// Set SetKBLED Parameters
+	CComVariant paramVt;
+	paramVt.vt = VT_INT;
+	paramVt.intVal = hex_value; // VALUES: 0x00001000 -> OFF  // 0x00001000 -> ON
+	const HRESULT n = paramVt.ChangeType(VT_I4);
+
+	if (FAILED(hRes = paramsInst->Put(_bstr_t(L"Data"), 0, &paramVt, NULL))) {
+		LOG_WARNING(L"CLEVO: could not set the argument. Error code = 0x" + std::to_wstring(hRes));
+		cout << "could not set the argument. Error code = 0x" << hex << hRes << endl;
+	}
+
+	// Execute
+	IWbemClassObject *results = NULL;
+	hRes = pService->ExecMethod(this_pointer.bstrVal, _bstr_t(L"SetKBLED"), 0, NULL, paramsInst, &results, NULL);
+	LOG_DEBUG(L"CLEVO: EXECUTE. Error code = 0x" + std::to_wstring(hRes));
+
+	// Clear Data
+	VariantClear(&paramVt);
+
+	return 0;
+}
+
+// Set KBLED: Using RGB
+HRESULT ClevoKBLED::SetKBLED(KBLEDAREA area, uint8_t color_r, uint8_t color_g, uint8_t color_b) {
+	// cout << hex << (((((area << 8) + color_r) << 8) + color_g) << 8) + color_b;
+	return ClevoKBLED::SetKBLED((((((area << 8) + color_r) << 8) + color_g) << 8) + color_b);
+}
+
+// Set KBLED: Using RGBA
+HRESULT ClevoKBLED::SetKBLED(KBLEDAREA area, uint8_t color_r, uint8_t color_g, uint8_t color_b, double alpha) {
+	if (alpha >= 1) { // Ignore all values over 1
+		return ClevoKBLED::SetKBLED(area, color_r, color_g, color_b);
+	} else {
+		return ClevoKBLED::SetKBLED(area, ClevoKBLED::ToInt(color_r*alpha), ClevoKBLED::ToInt(color_g*alpha), ClevoKBLED::ToInt(color_b*alpha));
+	}
+}
+
+// Set KBLED Mode
+HRESULT ClevoKBLED::SetKBLEDMode(KBLEDMODE mode) {
+	return ClevoKBLED::SetKBLED(mode);
+}
+
+// Helper Functions
+int ClevoKBLED::ToInt(double x) {
+	double dx = x < 0.0 ? -0.5 : 0.5;
+	return static_cast<int>(x + dx);
+}
+
+template< typename T >
+string ClevoKBLED::intToHexStr(T i){
+	std::stringstream stream;
+	stream << "0x"
+		<< std::setfill('0') << std::setw(sizeof(T) * 2)
+		<< std::hex << i;
+	return stream.str();
+}

--- a/src/Devices/Libraries/ClevoKBLED.h
+++ b/src/Devices/Libraries/ClevoKBLED.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <iostream>
+#include <WbemCli.h>  
+#include <atlbase.h>
+#include <comutil.h>
+
+#include "../../Timelines/LightColor.h"
+#include "../../Utils/BlockingLightColor.h"
+
+using namespace std;
+using namespace lightfx::timelines;
+
+// Enums
+enum KBLEDAREA : uint8_t {
+	ColorKBLeft = 0xF0,
+	ColorKBCenter = 0xF1,
+	ColorKBRight = 0xF2,
+	ColorTouchpad = 0xF3
+};
+
+enum KBLEDMODE : uint32_t {
+	KBLEDON = 0x00001000,
+	KBLEDOFF = 0x0000A000,
+	FXDance = 0x80000000,
+	FXBreath = 0x30000000,
+	FXBlink = 0xA0000000,
+	FXRandom = 0x90000000,
+	FXSweep = 0xB0000000
+};
+
+// Class Definition
+class ClevoKBLED {
+	public:
+		HRESULT Initialize();
+		HRESULT Release();
+		HRESULT SetKBLEDMode(KBLEDMODE mode);
+		HRESULT SetKBLED(uint32_t hex_value);
+		HRESULT SetKBLED(KBLEDAREA area, uint8_t color_r, uint8_t color_g, uint8_t color_b);
+		HRESULT SetKBLED(KBLEDAREA area, uint8_t color_r, uint8_t color_g, uint8_t color_b, double alpha);
+
+	private:
+		int ToInt(double x);
+
+		IWbemServices* pService = NULL;
+		IWbemClassObject *paramsInst = NULL;
+		VARIANT this_pointer;
+};

--- a/src/LightFXExports.cpp
+++ b/src/LightFXExports.cpp
@@ -29,11 +29,11 @@ using namespace lightfx::utils;
 #pragma region Converters
 
 LFX_POSITION DeviceLightPositionToLfxPosition(const DeviceLightPosition position) {
-    return LFX_POSITION{ position.x, position.y, position.z };
+    return LFX_POSITION{ static_cast<unsigned char>(position.x), static_cast<unsigned char>(position.y), static_cast<unsigned char>(position.z) };
 }
 
 LFX_COLOR LightColorToLfxColor(const LightColor color) {
-    return LFX_COLOR{ color.red, color.green, color.blue, color.brightness };
+    return LFX_COLOR{ static_cast<unsigned char>(color.red), static_cast<unsigned char>(color.green), static_cast<unsigned char>(color.blue), static_cast<unsigned char>(color.brightness) };
 }
 
 LFX_COLOR IntToLfxColor(const unsigned int color) {

--- a/src/LightFXExtender.vcxproj
+++ b/src/LightFXExtender.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug_Tests|Win32">
       <Configuration>Debug_Tests</Configuration>
@@ -42,52 +42,52 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_Tests|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_Tests|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_Tests|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_Tests|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
@@ -301,11 +301,13 @@
     <ClInclude Include="Config\ConfigFile.h" />
     <ClInclude Include="Config\MainConfigFile.h" />
     <ClInclude Include="Devices\Device.h" />
+    <ClInclude Include="Devices\DeviceClevo.h" />
     <ClInclude Include="Devices\DeviceCorsair.h" />
     <ClInclude Include="Devices\DeviceLightFX.h" />
     <ClInclude Include="Devices\DeviceLightpack.h" />
     <ClInclude Include="Devices\DeviceLogitech.h" />
     <ClInclude Include="Devices\DeviceRazer.h" />
+    <ClInclude Include="Devices\Libraries\ClevoKBLED.h" />
     <ClInclude Include="Devices\Proxies\CUESDKProxy.h" />
     <ClInclude Include="Devices\Proxies\DeviceLibraryProxy.h" />
     <ClInclude Include="Devices\Proxies\LightFX2Proxy.h" />
@@ -328,6 +330,7 @@
     <ClInclude Include="Timelines\LightTimeline.h" />
     <ClInclude Include="Timelines\LightTimelineItem.h" />
     <ClInclude Include="Timelines\Timeline.h" />
+    <ClInclude Include="Utils\BlockingLightColor.h" />
     <ClInclude Include="Utils\FileIO.h" />
     <ClInclude Include="Utils\Log.h" />
     <ClInclude Include="Utils\String.h" />
@@ -346,11 +349,13 @@
     <ClCompile Include="Config\ConfigFile.cpp" />
     <ClCompile Include="Config\MainConfigFile.cpp" />
     <ClCompile Include="Devices\Device.cpp" />
+    <ClCompile Include="Devices\DeviceClevo.cpp" />
     <ClCompile Include="Devices\DeviceCorsair.cpp" />
     <ClCompile Include="Devices\DeviceLightFX.cpp" />
     <ClCompile Include="Devices\DeviceLightpack.cpp" />
     <ClCompile Include="Devices\DeviceLogitech.cpp" />
     <ClCompile Include="Devices\DeviceRazer.cpp" />
+    <ClCompile Include="Devices\Libraries\ClevoKBLED.cpp" />
     <ClCompile Include="Devices\Proxies\CUESDKProxy.cpp" />
     <ClCompile Include="Devices\Proxies\DeviceLibraryProxy.cpp" />
     <ClCompile Include="Devices\Proxies\LightFX2Proxy.cpp" />
@@ -368,6 +373,7 @@
     <ClCompile Include="Timelines\LightTimeline.cpp" />
     <ClCompile Include="Timelines\LightTimelineItem.cpp" />
     <ClCompile Include="Timelines\Timeline.cpp" />
+    <ClCompile Include="Utils\BlockingLightColor.cpp" />
     <ClCompile Include="Utils\FileIO.cpp" />
     <ClCompile Include="Utils\Log.cpp" />
     <ClCompile Include="Utils\String.cpp" />

--- a/src/LightFXExtender.vcxproj.filters
+++ b/src/LightFXExtender.vcxproj.filters
@@ -132,6 +132,15 @@
     <ClInclude Include="Devices\Proxies\RzChromaSDKProxy.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Devices\DeviceClevo.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Devices\Libraries\ClevoKBLED.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Utils\BlockingLightColor.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="LightFXExtender.rc">
@@ -229,6 +238,15 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="Devices\Proxies\RzChromaSDKProxy.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Devices\DeviceClevo.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Devices\Libraries\ClevoKBLED.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Utils\BlockingLightColor.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/src/Managers/DeviceManager.cpp
+++ b/src/Managers/DeviceManager.cpp
@@ -13,6 +13,7 @@
 #include "../Devices/DeviceLogitech.h"
 #include "../Devices/DeviceCorsair.h"
 #include "../Devices/DeviceRazer.h"
+#include "../Devices/DeviceClevo.h"
 #include "../Utils/FileIO.h"
 #include "../Utils/Log.h"
 #include "../Utils/String.h"
@@ -34,13 +35,21 @@ namespace lightfx {
             auto config = this->GetLightFXExtender()->GetConfigManager()->GetMainConfig();
             this->updateDevicesInterval = config->TimelineUpdateInterval;
 
+			// Clevo Device
+			auto clevo = make_shared<DeviceClevo>(); // TODO: Add Touchpad Configuration
+			this->AddChild(L"Clevo", clevo);
+			if (clevo->Initialize()) {
+				++i;
+			}
+
+			// LightPack Device
             auto lightpack = make_shared<DeviceLightpack>(config->LightpackHost, config->LightpackPort, config->LightpackKey);
             this->AddChild(L"Lightpack", lightpack);
             if (lightpack->Initialize()) {
                 ++i;
             }
 
-
+			// Logitech Device
             auto logitech = make_shared<DeviceLogitech>();
             logitech->SetRange(config->LogitechColorRangeOutMin, config->LogitechColorRangeOutMax, config->LogitechColorRangeInMin, config->LogitechColorRangeInMax);
             this->AddChild(L"Logitech", logitech);
@@ -50,13 +59,14 @@ namespace lightfx {
                 ++i;
             }
 
-            
+            // Corsair Device
             auto corsair = make_shared<DeviceCorsair>();
             this->AddChild(L"Corsair", corsair);
             if (corsair->Initialize()) {
                 ++i;
             }
             
+			// Razer Device
             auto razer = make_shared<DeviceRazer>();
             razer->SetHardware(config->RazerUseWithKeyboard, config->RazerUseWithMouse, config->RazerUseWithHeadset, config->RazerUseWithMousepad, config->RazerUseWithKeypad);
             this->AddChild(L"Razer", razer);

--- a/src/Settings.aiis
+++ b/src/Settings.aiis
@@ -1,0 +1,212 @@
+{
+  "__type": "ArtOfTest.WebAii.Design.UserSettings",
+  "__value": {
+    "UseHttpProxy": false,
+    "RecordjQueryInDescriptorsIfPossible": true,
+    "ShouldDeleteElement": false,
+    "SkipDeleteElementPrompt": false,
+    "HideFindExpressionWelcome": false,
+    "MenuHoldTime": 1.0,
+    "SilverlightConnectTimeout": 60000,
+    "BaseClassName": "BaseWebAiiTest",
+    "UrlRecordMode": 2,
+    "HighlightBorderColor": -65536,
+    "HighlightBorderSize": 1,
+    "CodeGenerationElementIdentificationType": 1,
+    "UrlHistory": [],
+    "AbsoluteDragDropRecording": true,
+    "ImageScalePercentage": 75,
+    "SelectedIdentificaitonScheme": "Html",
+    "IdentificationSchemes": {
+      "Html": {
+        "__type": "ArtOfTest.Common.Design.Translation.IdentificationOptionsScheme",
+        "__value": {
+          "CheckFindParamUniqueness": true,
+          "AutoDetectTestRegions": true,
+          "TryAttributeCombinations": true,
+          "AlwaysAssertTagName": true,
+          "IdentificationsPerTag": {
+            "All Elements": {
+              "__type": "ArtOfTest.Common.Design.Translation.IdentificationDescriptorList",
+              "__value": [
+                {
+                  "__type": "ArtOfTest.WebAii.Design.Translation.HtmlIdentificationDescriptor",
+                  "__value": {
+                    "IsLocked": false,
+                    "SearchType": 0,
+                    "AttributeName": "id"
+                  }
+                },
+                {
+                  "__type": "ArtOfTest.WebAii.Design.Translation.HtmlIdentificationDescriptor",
+                  "__value": {
+                    "IsLocked": false,
+                    "SearchType": 0,
+                    "AttributeName": "name"
+                  }
+                },
+                {
+                  "__type": "ArtOfTest.WebAii.Design.Translation.HtmlIdentificationDescriptor",
+                  "__value": {
+                    "IsLocked": false,
+                    "SearchType": 0,
+                    "AttributeName": "src"
+                  }
+                },
+                {
+                  "__type": "ArtOfTest.WebAii.Design.Translation.HtmlIdentificationDescriptor",
+                  "__value": {
+                    "IsLocked": false,
+                    "SearchType": 0,
+                    "AttributeName": "href"
+                  }
+                },
+                {
+                  "__type": "ArtOfTest.WebAii.Design.Translation.HtmlIdentificationDescriptor",
+                  "__value": {
+                    "IsLocked": false,
+                    "SearchType": 0,
+                    "AttributeName": "value"
+                  }
+                },
+                {
+                  "__type": "ArtOfTest.WebAii.Design.Translation.HtmlIdentificationDescriptor",
+                  "__value": {
+                    "IsLocked": false,
+                    "SearchType": 0,
+                    "AttributeName": "alt"
+                  }
+                },
+                {
+                  "__type": "ArtOfTest.WebAii.Design.Translation.HtmlIdentificationDescriptor",
+                  "__value": {
+                    "IsLocked": true,
+                    "SearchType": 1,
+                    "AttributeName": null
+                  }
+                },
+                {
+                  "__type": "ArtOfTest.WebAii.Design.Translation.HtmlIdentificationDescriptor",
+                  "__value": {
+                    "IsLocked": true,
+                    "SearchType": 8,
+                    "AttributeName": null
+                  }
+                }
+              ]
+            }
+          },
+          "TechnologyType": 1
+        }
+      },
+      "Silverlight": {
+        "__type": "ArtOfTest.Common.Design.Translation.IdentificationOptionsScheme",
+        "__value": {
+          "CheckFindParamUniqueness": true,
+          "AutoDetectTestRegions": true,
+          "TryAttributeCombinations": true,
+          "AlwaysAssertTagName": true,
+          "IdentificationsPerTag": {
+            "All Elements": {
+              "__type": "ArtOfTest.Common.Design.Translation.IdentificationDescriptorList",
+              "__value": [
+                {
+                  "__type": "ArtOfTest.WebAii.Design.Translation.Silverlight.SilverlightIdentificationDescriptor",
+                  "__value": {
+                    "IsLocked": false,
+                    "SearchType": 0,
+                    "AttributeName": null
+                  }
+                },
+                {
+                  "__type": "ArtOfTest.WebAii.Design.Translation.Silverlight.SilverlightIdentificationDescriptor",
+                  "__value": {
+                    "IsLocked": false,
+                    "SearchType": 5,
+                    "AttributeName": null
+                  }
+                },
+                {
+                  "__type": "ArtOfTest.WebAii.Design.Translation.Silverlight.SilverlightIdentificationDescriptor",
+                  "__value": {
+                    "IsLocked": false,
+                    "SearchType": 1,
+                    "AttributeName": null
+                  }
+                },
+                {
+                  "__type": "ArtOfTest.WebAii.Design.Translation.Silverlight.SilverlightIdentificationDescriptor",
+                  "__value": {
+                    "IsLocked": true,
+                    "SearchType": 6,
+                    "AttributeName": null
+                  }
+                }
+              ]
+            }
+          },
+          "TechnologyType": 2
+        }
+      }
+    },
+    "UnitTypeTypeGeneration": 1,
+    "RecorderBaseUrl": "",
+    "IsStoryBoardCapturingEnabled": true,
+    "SimulateRealClickByDefault": false,
+    "SimulateRealTypingByDefault": false,
+    "SimulateRealSilverlightUserByDefault": true,
+    "DefaultDropDownSelection": 1,
+    "QuickExecutionElementWaitTimeout": 15000,
+    "QuickExecutionClientReadyTimeout": 60000,
+    "QcServerUrl": null,
+    "QcUserName": "",
+    "QcPassword": "",
+    "QcSkipAuthDialog": false,
+    "QcDomain": null,
+    "QcProject": null,
+    "TfsUserName": "",
+    "TfsPassword": "",
+    "TfsSkipAuthDialog": true,
+    "TfsDomain": "",
+    "TeamPulseServerUrl": "",
+    "TpUserName": "",
+    "TpPassword": "",
+    "TpUseWindowsAuth": false,
+    "TpSkipAuthDialog": false,
+    "TpDefaultProjectId": -1,
+    "RecordWpfWindowStateChanged": false,
+    "PromptNameOnAddElement": true,
+    "DefaultWPFApplication": null,
+    "UseLegacySilverlightFindLogic": false,
+    "ProjectGuid": "33e359f0-8a96-4450-84c4-4919c68e65c0",
+    "SourceControlRepository": null,
+    "IsOnline": false,
+    "ProjectLanguage": 2,
+    "ProjectReferences": [
+      "System",
+      "System.Core",
+      "ArtOfTest.WebAii, Version=2016.2.630.0, Culture=neutral, PublicKeyToken=4fd5f65be123776c",
+      "ArtOfTest.WebAii.Design, Version=2016.2.630.0, Culture=neutral, PublicKeyToken=4fc62bbc3827ab1d",
+      "Telerik.WebAii.Controls.Html, Version=2016.2.630.0, Culture=neutral, PublicKeyToken=528163f3e645de45",
+      "Telerik.WebAii.Controls.Xaml, Version=2016.2.630.0, Culture=neutral, PublicKeyToken=528163f3e645de45",
+      "Telerik.WebAii.Controls.Xaml.Wpf, Version=2016.2.630.0, Culture=neutral, PublicKeyToken=528163f3e645de45",
+      "Telerik.TestingFramework.Controls.KendoUI, Version=2016.2.630.0, Culture=neutral, PublicKeyToken=528163f3e645de45"
+    ],
+    "ScheduleServerUrl": "http://localhost:8009",
+    "IsScheduleServerRemote": false,
+    "ProjectVersion": "2016.2.610.0",
+    "Namespace": "LightFXExtender",
+    "AssemblyName": "LightFXExtender",
+    "OutputFolder": "bin",
+    "ExcludedFiles": [],
+    "DisabledTranslators": [],
+    "SkipFindExpressionSetDataDrivenWarning": false,
+    "BugTrackerPersistableSettings": {},
+    "ActiveBugTrackers": [],
+    "BugTitleMask": "{Step name} step on {Test name} test failed.",
+    "BugAddAttachment": true,
+    "BugAutoSubmit": false,
+    "BugDescriptionMask": "{Description}",
+    "SelectedBrowserOption": 0
+  }
+}

--- a/src/Utils/BlockingLightColor.cpp
+++ b/src/Utils/BlockingLightColor.cpp
@@ -1,0 +1,82 @@
+#ifndef LFXE_EXPORTS
+#define LFXE_EXPORTS
+#endif
+
+#include <vector>
+#include <condition_variable>
+#include <mutex>
+
+#include "BlockingLightColor.h"
+#include "../Timelines/LightColor.h"
+
+using namespace std;
+using namespace lightfx::timelines;
+
+mutex  color_m;
+mutex  modified_m;
+mutex  threadstate_m;
+
+mutex  m;
+unique_lock<mutex> data_lock(m);
+condition_variable cv;
+
+vector<LightColor> color_vector; // TODO: This is probably static, and not the best solution. How to use the private variable color? 
+
+bool modified = false; // Variable to check if value got modified while color update
+bool releaseThreadState = false;
+
+namespace lightfx {
+    namespace utils {
+
+		void BlockingLightColor::setLightColor(const vector<LightColor>& colors) {
+			// Set Color
+			color_m.lock();
+			color_vector = colors;
+			// this->color = colors; // Doesnt works? Or class instance is not passing between calls
+			color_m.unlock();
+
+			// Modified Status
+			modified_m.lock();
+			modified = true;
+			modified_m.unlock();
+
+			// Notify Thread
+			cv.notify_all();
+		}
+
+		// Get Light Color with Blocking Behaviour
+		const vector<LightColor> BlockingLightColor::getLightColor() {
+			modified_m.lock();
+			if ( modified == true ) {
+				modified = false;
+				modified_m.unlock();
+			}else {
+				modified_m.unlock();
+				cv.wait(data_lock);
+			}
+			//return this->color; // Doesnt works? Or class instance is not passing between calls
+			return color_vector;
+		}
+
+		// Mark Thread as Released
+		void BlockingLightColor::releaseThread() {
+			// Mark Thread as Released
+			threadstate_m.lock();
+			releaseThreadState = true;
+			threadstate_m.unlock();
+
+			// Modified Status
+			modified_m.lock();
+			modified = true;
+			modified_m.unlock();
+
+			// Notify Thread
+			cv.notify_all();
+		}
+
+		// Get Thread Release State
+		bool BlockingLightColor::getReleaseThreadState() {
+			return releaseThreadState;
+		}
+    }
+}

--- a/src/Utils/BlockingLightColor.h
+++ b/src/Utils/BlockingLightColor.h
@@ -1,0 +1,32 @@
+#pragma once
+
+// Standard includes
+#include <string>
+#include <sstream>
+#include <vector>
+#include <locale>
+#include <codecvt>
+
+// API exports
+#include "../Common/ApiExports.h"
+#include "../Timelines/LightColor.h"
+
+using namespace std;
+using namespace lightfx::timelines;
+
+namespace lightfx {
+    namespace utils {
+		class BlockingLightColor {
+		public:
+			void setLightColor(const vector<LightColor>& colors);
+			const vector<LightColor> getLightColor();
+
+			void releaseThread();
+			bool getReleaseThreadState();
+
+		private:
+			vector<LightColor> color;
+		};
+      
+    }
+}

--- a/src/Utils/BlockingLightColor.h
+++ b/src/Utils/BlockingLightColor.h
@@ -21,6 +21,10 @@ namespace lightfx {
 			void setLightColor(const vector<LightColor>& colors);
 			const vector<LightColor> getLightColor();
 
+			void setInitialized(bool initialized);
+			bool getInitialized();
+			void resetInitialized();
+
 			void releaseThread();
 			bool getReleaseThreadState();
 

--- a/tests/Settings.aiis
+++ b/tests/Settings.aiis
@@ -1,0 +1,212 @@
+{
+  "__type": "ArtOfTest.WebAii.Design.UserSettings",
+  "__value": {
+    "UseHttpProxy": false,
+    "RecordjQueryInDescriptorsIfPossible": true,
+    "ShouldDeleteElement": false,
+    "SkipDeleteElementPrompt": false,
+    "HideFindExpressionWelcome": false,
+    "MenuHoldTime": 1.0,
+    "SilverlightConnectTimeout": 60000,
+    "BaseClassName": "BaseWebAiiTest",
+    "UrlRecordMode": 2,
+    "HighlightBorderColor": -65536,
+    "HighlightBorderSize": 1,
+    "CodeGenerationElementIdentificationType": 1,
+    "UrlHistory": [],
+    "AbsoluteDragDropRecording": true,
+    "ImageScalePercentage": 75,
+    "SelectedIdentificaitonScheme": "Html",
+    "IdentificationSchemes": {
+      "Html": {
+        "__type": "ArtOfTest.Common.Design.Translation.IdentificationOptionsScheme",
+        "__value": {
+          "CheckFindParamUniqueness": true,
+          "AutoDetectTestRegions": true,
+          "TryAttributeCombinations": true,
+          "AlwaysAssertTagName": true,
+          "IdentificationsPerTag": {
+            "All Elements": {
+              "__type": "ArtOfTest.Common.Design.Translation.IdentificationDescriptorList",
+              "__value": [
+                {
+                  "__type": "ArtOfTest.WebAii.Design.Translation.HtmlIdentificationDescriptor",
+                  "__value": {
+                    "IsLocked": false,
+                    "SearchType": 0,
+                    "AttributeName": "id"
+                  }
+                },
+                {
+                  "__type": "ArtOfTest.WebAii.Design.Translation.HtmlIdentificationDescriptor",
+                  "__value": {
+                    "IsLocked": false,
+                    "SearchType": 0,
+                    "AttributeName": "name"
+                  }
+                },
+                {
+                  "__type": "ArtOfTest.WebAii.Design.Translation.HtmlIdentificationDescriptor",
+                  "__value": {
+                    "IsLocked": false,
+                    "SearchType": 0,
+                    "AttributeName": "src"
+                  }
+                },
+                {
+                  "__type": "ArtOfTest.WebAii.Design.Translation.HtmlIdentificationDescriptor",
+                  "__value": {
+                    "IsLocked": false,
+                    "SearchType": 0,
+                    "AttributeName": "href"
+                  }
+                },
+                {
+                  "__type": "ArtOfTest.WebAii.Design.Translation.HtmlIdentificationDescriptor",
+                  "__value": {
+                    "IsLocked": false,
+                    "SearchType": 0,
+                    "AttributeName": "value"
+                  }
+                },
+                {
+                  "__type": "ArtOfTest.WebAii.Design.Translation.HtmlIdentificationDescriptor",
+                  "__value": {
+                    "IsLocked": false,
+                    "SearchType": 0,
+                    "AttributeName": "alt"
+                  }
+                },
+                {
+                  "__type": "ArtOfTest.WebAii.Design.Translation.HtmlIdentificationDescriptor",
+                  "__value": {
+                    "IsLocked": true,
+                    "SearchType": 1,
+                    "AttributeName": null
+                  }
+                },
+                {
+                  "__type": "ArtOfTest.WebAii.Design.Translation.HtmlIdentificationDescriptor",
+                  "__value": {
+                    "IsLocked": true,
+                    "SearchType": 8,
+                    "AttributeName": null
+                  }
+                }
+              ]
+            }
+          },
+          "TechnologyType": 1
+        }
+      },
+      "Silverlight": {
+        "__type": "ArtOfTest.Common.Design.Translation.IdentificationOptionsScheme",
+        "__value": {
+          "CheckFindParamUniqueness": true,
+          "AutoDetectTestRegions": true,
+          "TryAttributeCombinations": true,
+          "AlwaysAssertTagName": true,
+          "IdentificationsPerTag": {
+            "All Elements": {
+              "__type": "ArtOfTest.Common.Design.Translation.IdentificationDescriptorList",
+              "__value": [
+                {
+                  "__type": "ArtOfTest.WebAii.Design.Translation.Silverlight.SilverlightIdentificationDescriptor",
+                  "__value": {
+                    "IsLocked": false,
+                    "SearchType": 0,
+                    "AttributeName": null
+                  }
+                },
+                {
+                  "__type": "ArtOfTest.WebAii.Design.Translation.Silverlight.SilverlightIdentificationDescriptor",
+                  "__value": {
+                    "IsLocked": false,
+                    "SearchType": 5,
+                    "AttributeName": null
+                  }
+                },
+                {
+                  "__type": "ArtOfTest.WebAii.Design.Translation.Silverlight.SilverlightIdentificationDescriptor",
+                  "__value": {
+                    "IsLocked": false,
+                    "SearchType": 1,
+                    "AttributeName": null
+                  }
+                },
+                {
+                  "__type": "ArtOfTest.WebAii.Design.Translation.Silverlight.SilverlightIdentificationDescriptor",
+                  "__value": {
+                    "IsLocked": true,
+                    "SearchType": 6,
+                    "AttributeName": null
+                  }
+                }
+              ]
+            }
+          },
+          "TechnologyType": 2
+        }
+      }
+    },
+    "UnitTypeTypeGeneration": 1,
+    "RecorderBaseUrl": "",
+    "IsStoryBoardCapturingEnabled": true,
+    "SimulateRealClickByDefault": false,
+    "SimulateRealTypingByDefault": false,
+    "SimulateRealSilverlightUserByDefault": true,
+    "DefaultDropDownSelection": 1,
+    "QuickExecutionElementWaitTimeout": 15000,
+    "QuickExecutionClientReadyTimeout": 60000,
+    "QcServerUrl": null,
+    "QcUserName": "",
+    "QcPassword": "",
+    "QcSkipAuthDialog": false,
+    "QcDomain": null,
+    "QcProject": null,
+    "TfsUserName": "",
+    "TfsPassword": "",
+    "TfsSkipAuthDialog": true,
+    "TfsDomain": "",
+    "TeamPulseServerUrl": "",
+    "TpUserName": "",
+    "TpPassword": "",
+    "TpUseWindowsAuth": false,
+    "TpSkipAuthDialog": false,
+    "TpDefaultProjectId": -1,
+    "RecordWpfWindowStateChanged": false,
+    "PromptNameOnAddElement": true,
+    "DefaultWPFApplication": null,
+    "UseLegacySilverlightFindLogic": false,
+    "ProjectGuid": "70094228-386c-4e84-a9d2-b23bb6be8ee6",
+    "SourceControlRepository": null,
+    "IsOnline": false,
+    "ProjectLanguage": 2,
+    "ProjectReferences": [
+      "System",
+      "System.Core",
+      "ArtOfTest.WebAii, Version=2016.2.630.0, Culture=neutral, PublicKeyToken=4fd5f65be123776c",
+      "ArtOfTest.WebAii.Design, Version=2016.2.630.0, Culture=neutral, PublicKeyToken=4fc62bbc3827ab1d",
+      "Telerik.WebAii.Controls.Html, Version=2016.2.630.0, Culture=neutral, PublicKeyToken=528163f3e645de45",
+      "Telerik.WebAii.Controls.Xaml, Version=2016.2.630.0, Culture=neutral, PublicKeyToken=528163f3e645de45",
+      "Telerik.WebAii.Controls.Xaml.Wpf, Version=2016.2.630.0, Culture=neutral, PublicKeyToken=528163f3e645de45",
+      "Telerik.TestingFramework.Controls.KendoUI, Version=2016.2.630.0, Culture=neutral, PublicKeyToken=528163f3e645de45"
+    ],
+    "ScheduleServerUrl": "http://localhost:8009",
+    "IsScheduleServerRemote": false,
+    "ProjectVersion": "2016.2.610.0",
+    "Namespace": "UnitTests",
+    "AssemblyName": "UnitTests",
+    "OutputFolder": "bin",
+    "ExcludedFiles": [],
+    "DisabledTranslators": [],
+    "SkipFindExpressionSetDataDrivenWarning": false,
+    "BugTrackerPersistableSettings": {},
+    "ActiveBugTrackers": [],
+    "BugTitleMask": "{Step name} step on {Test name} test failed.",
+    "BugAddAttachment": true,
+    "BugAutoSubmit": false,
+    "BugDescriptionMask": "{Description}",
+    "SelectedBrowserOption": 0
+  }
+}

--- a/tests/UnitTests.vcxproj
+++ b/tests/UnitTests.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug_Tests|Win32">
       <Configuration>Debug_Tests</Configuration>
@@ -27,21 +27,21 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_Tests|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <UseOfMfc>false</UseOfMfc>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_Tests|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <UseOfMfc>false</UseOfMfc>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_Tests|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
     <UseOfMfc>false</UseOfMfc>
@@ -49,7 +49,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_Tests|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
     <UseOfMfc>false</UseOfMfc>


### PR DESCRIPTION
So this is my working implementation to have Clevo devices support in LightFX-Extender.
In order to make it work, the game has to have Administrator rights because the Clevo developers decided to require Admin rights to access the Clevo WMI interface.

Stuff Missing and TODO's:
- I still don't know how the **LightData** positioning works. Is it in centimeters or should it be some known index, do you have to use some kind of special description (Like "Touchpad" "KeyboardLeft" or anything?
- This is my first C++ implementation (I'm a Java programmer), so it would be nice if somebody with C++ knowledge could have a look at the code to see if there is something wrong, memory leaks, or whatever. Any constructive commentaries are very welcome.
- In my **BlockingLightColor** implementation, I was trying to use private variables, but I never managed to get them to work, so I'm using static variables (if I'm not wrong), which is not what was intended but it works. If somebody is able to point me out how to achieve private non-static variables I would apreciate that.

**ClevoKBLED** is separate on purpose, as I'm using it in other projects. So if I update or find some bug in it I can just update that file and not reprogram every project. (Hope that's OK).

Greetings.
